### PR TITLE
(fix) stdio for cli

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -30,7 +30,7 @@ brews:
   - repository:
       owner: fogfish
       name: iq
-    folder: Formula
+    directory: Formula
     goarm: "7"
     homepage:  https://github.com/fogfish/iq
     description: iq (Intelligent Query) is a fast and lightweight CLI for running LLM-powered agents.

--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -59,8 +59,9 @@ suited for temporary or disposable file queues.
 See more info https://github.com/fogfish/iq
 	`,
 	Example: `
-	iq ask -p prompt.yml
-	echo "What are colors of the thing in the attached document?" | iq ask
+	iq ask -p prompt.yml -o ./output
+	
+	echo "What are colors of the thing in the attached document?" | iq ask -o ./output
 	`,
 	SilenceUsage:  true,
 	SilenceErrors: true,

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -37,7 +37,8 @@ var execCmd = &cobra.Command{
 	Use:   "task",
 	Short: "execute a workflow using LLM instructions",
 	Long: `
-TBD
+Used to run a full workflow: a prompt that describes a multi-step task and
+leverages built-in tools to read, write, and manipulate files as needed.
 
 See more info https://github.com/fogfish/iq
 	`,
@@ -74,7 +75,7 @@ func exec(cmd *cobra.Command, args []string) error {
 	}
 
 	for _, file := range args {
-		spinner.Describe(fmt.Sprintf("processing with %s ...", file))
+		spinner.Describe(fmt.Sprintf("processing with %s", ellipses(file)))
 		b, err := os.ReadFile(file)
 		if err != nil {
 			return err

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -87,7 +87,18 @@ Run 'iq help' for guidance.
 See more info https://github.com/fogfish/iq
 	`,
 	Example: `
-	iq
+	## Send a prompt to LLM
+	iq tell -p myprompt.yml
+	iq tell -p myprompt.yml FILE1 ...
+
+	## Execute a workflow using LLM instructions
+	iq exec -p mytask.yml
+	iq exec -p mytask.yml FILE1 FILE2 ...
+	echo "Using available tools draw the rainbow?" | iq exec --python
+
+	## Process files with LLM
+	iq ask -p prompt.yml -o ./output
+	echo "What are colors of the thing in the attached document?" | iq ask -o ./output
 	`,
 	SilenceUsage: true,
 	Run:          func(cmd *cobra.Command, args []string) { cmd.Help() },
@@ -150,11 +161,15 @@ func parsePrompt() (*viper.Viper, error) {
 		return nil, err
 	}
 
-	if fi.Size() > 0 {
-		return prompt.Parse(os.Stdin)
+	if fi.Mode()&os.ModeCharDevice != 0 {
+		return nil, fmt.Errorf("no prompt data in stdin")
 	}
 
-	return nil, fmt.Errorf("undefined prompt")
+	// if fi.Size() > 0 {
+	return prompt.Parse(os.Stdin)
+	// }
+
+	// return nil, fmt.Errorf("undefined prompt")
 }
 
 func agentForPrompts() (*service.Prompter, *viper.Viper, error) {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -66,7 +66,7 @@ suited for temporary or disposable file queues.
 See more info https://github.com/fogfish/iq
 	`,
 	Example: `
-	iq run -p task.yml
+	iq run -p task.yml -o ./output
 	`,
 	SilenceUsage:  true,
 	SilenceErrors: true,

--- a/cmd/tag.go
+++ b/cmd/tag.go
@@ -51,7 +51,7 @@ workflows.
 See more info https://github.com/fogfish/iq
 	`,
 	Example: `
-	iq
+	iq tag -p classify.yml -o ./output
 	`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
@@ -80,15 +80,8 @@ func tag(cmd *cobra.Command, args []string) error {
 
 	q.PartitionFile(context.Background(), "/",
 		func(ctx context.Context, path string, b []byte) (string, error) {
-			if len(path) > 80 {
-				spinner.Describe(path[:80])
-			} else {
-				spinner.Describe(path)
-			}
-			defer func() {
-				os.Stderr.WriteString("\n")
-				spinner.Reset()
-			}()
+			spinner.Describe(ellipses(path))
+			defer respinner(spinner)
 
 			req.Set(spec.YAML_BLOB, string(b))
 			reply, err := agt.PromptOnce(ctx, req)

--- a/cmd/tell.go
+++ b/cmd/tell.go
@@ -25,7 +25,9 @@ var tellCmd = &cobra.Command{
 	Use:   "tell",
 	Short: "send a prompt to LLM",
 	Long: `
-TBD
+Send a standalone prompt and receive an immediate response from LLM. It is ideal
+for asking questions, drafting text, or running quick ideas before building the
+workflow pipelines.
 
 See more info https://github.com/fogfish/iq
 	`,
@@ -62,7 +64,7 @@ func tell(cmd *cobra.Command, args []string) error {
 	}
 
 	for _, file := range args {
-		spinner.Describe(fmt.Sprintf("prompting with %s ...", file))
+		spinner.Describe(fmt.Sprintf("prompting with %s", ellipses(file)))
 		b, err := os.ReadFile(file)
 		if err != nil {
 			return err


### PR DESCRIPTION
* detect stream type at stdin
* improve examples for all commands
* truncate long file names for `exec`, `tell` commands
* fix progress bar for `tag` command